### PR TITLE
Add the ability to deny tags for flow filtering

### DIFF
--- a/webapp/static/js/api.js
+++ b/webapp/static/js/api.js
@@ -20,9 +20,10 @@ export default class Api {
    * @param {Array} services Keep only flows matching these IP address and ports
    * @param {String} appProto Keep only flows matching this app-layer protocol
    * @param {String} search Search for this glob pattern in flows payloads
-   * @param {Array} tags Keep only flows matching these tags
+   * @param {Array} requiredTags Keep only flows matching these tags
+   * @param {Array} deniedTags Deny flows matching these tags
    */
-  async listFlows (timestampFrom, timestampTo, services, appProto, search, tags) {
+  async listFlows (timestampFrom, timestampTo, services, appProto, search, requiredTags, deniedTags) {
     const url = new URL(`${location.origin}${location.pathname}api/flow`)
     if (typeof timestampFrom === 'number') {
       url.searchParams.append('from', timestampFrom)
@@ -39,8 +40,11 @@ export default class Api {
     if (search) {
       url.searchParams.append('search', search)
     }
-    tags?.forEach((t) => {
+    requiredTags?.forEach((t) => {
       url.searchParams.append('tag', t)
+    })
+    deniedTags?.forEach((t) => {
+      url.searchParams.append('deny_tag', t)
     })
     const response = await fetch(url.href, {})
     if (!response.ok) {


### PR DESCRIPTION
With theses changes, there are now `required` tags and `denied` tags.

Each flow must contains all required tags but none denied tags.

In the filter UI, the `shift` key acts as an effect inverter. 

Click event rules table :
```
inactive => click => required
inactive => shift+click => denied

required => click => inactive
required => shift+click => denied

denied => click => inactive
denied => shift+click => required
```

In this example, `GIF` is required and `SLOW` is denied :

![image](https://github.com/ANSSI-FR/shovel/assets/20862992/2fb39d62-b4e4-4f23-b021-8795d25d803a)
