### PR TITLE
Dates: use default locale to display dates

### DIFF
--- a/webapp/static/js/flowdisplay.js
+++ b/webapp/static/js/flowdisplay.js
@@ -156,9 +156,9 @@ class FlowDisplay {
       fractionalSecondDigits: 3
     }
     const dateStart = new Date(flow.flow.ts_start)
-    const formatedDateStart = new Intl.DateTimeFormat('en-US', dateParams).format(dateStart)
+    const formatedDateStart = new Intl.DateTimeFormat(undefined, dateParams).format(dateStart)
     const dateEnd = new Date(flow.flow.ts_end)
-    const formatedDateEnd = new Intl.DateTimeFormat('en-US', dateParams).format(dateEnd)
+    const formatedDateEnd = new Intl.DateTimeFormat(undefined, dateParams).format(dateEnd)
 
     // Change document title
     document.title = `${flow.flow.dest_ipport} - Shovel`

--- a/webapp/static/js/flowlist.js
+++ b/webapp/static/js/flowlist.js
@@ -329,7 +329,7 @@ class FlowList {
     flows.forEach((flow) => {
       const date = new Date(flow.ts_start)
       const startDate = new Intl.DateTimeFormat(
-        'en-US',
+        undefined,
         { hour: 'numeric', minute: 'numeric', second: 'numeric', fractionalSecondDigits: 1 }
       ).format(date)
 


### PR DESCRIPTION
Shovel uses `Intl.DateTimeFormat` to format times. This commmit removes the hardcoded `en-US` locale to use the locale defined by the user.

This fixes dates using 12-hours time (AM/PM) instead of 24-hours time on user agents that are configured to use 24-hours times.

It also affects the dates format (MM/DD/YYYY).

Before:
```
From 7/20/2024, 11:17:59.638 PM to 7/20/2024, 11:17:59.936 PM, tick 557
```

After (locale `en-GB`):
```
From 20/07/2024, 23:17:59.638 to 20/07/2024, 23:17:59.936, tick 557
```