### PR TITLE
Add netcat-openbsd to Suricata image for PCAP_OVER_IP

### DIFF
--- a/suricata/Dockerfile
+++ b/suricata/Dockerfile
@@ -7,7 +7,7 @@ COPY ./suricata-eve-sqlite-output/ /src/
 RUN RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 
 FROM alpine:3.20
-RUN apk add --no-cache suricata lua5.1-sqlite
+RUN apk add --no-cache suricata lua5.1-sqlite netcat-openbsd
 COPY . /suricata
 COPY --from=builder /src/target/release/libeve_sqlite_output.so /suricata/
 ENTRYPOINT ["/suricata/entrypoint.sh"]


### PR DESCRIPTION
The Suricata entrypoint.sh uses `nc -d` to detach from stdin when using PCAP_OVER_IP mode, however the builtin nc of BusyBox does not have this flag.

This ensures that netcat-openbsd is installed so it can use this flag.